### PR TITLE
Fix race condition for Copy.

### DIFF
--- a/progress.go
+++ b/progress.go
@@ -6,58 +6,69 @@ import (
 	"io"
 )
 
-// transmitter is the monitoring object for a download
-// or upload. It is comprised of the raw progress, as well
-// as channels for reporting progress and errors.
+// transmitter monitors copying progress. It contains the current progress
+// and channels to report the progress and any errors that occur.
 type transmitter struct {
-	io.Reader
-	io.Writer
+	src          io.Reader
 	current      int64
 	total        int64
 	progressChan chan *Status
 	errorChan    chan error
 }
 
-func newTransmitter(dst io.Writer, src io.Reader) *transmitter {
+// newTransmitter creates a transmitter reading from src a total of n bytes.
+func newTransmitter(src io.Reader, n int64) *transmitter {
 	return &transmitter{
-		Writer:       dst,
-		Reader:       src,
+		src:          src,
+		total:        n,
 		progressChan: make(chan *Status),
 		errorChan:    make(chan error),
 	}
 }
 
-// closeChannels closes all channels associated with
-// the transmitter.
-func (t *transmitter) closeChannels() {
+// Close closes all channels associated with the transmitter.
+func (t *transmitter) Close() error {
 	close(t.progressChan)
 	close(t.errorChan)
+	return nil
 }
 
-// Read is the implementation of the transmitter's io.Reader
-// read method. It increments current progress and reports
-// progress to the associated progressChannel.
+// Read implements io.Reader, reading from the source and incrementing
+// the progress and reporting it to the progress channel.
 func (t *transmitter) Read(p []byte) (int, error) {
-	n, err := t.Reader.Read(p)
-	t.current += int64(n)
-	t.progressChan <- &Status{
-		Current: t.current,
-		Total:   t.total,
+	n, err := t.src.Read(p)
+	if n > 0 {
+		t.current += int64(n)
+		t.progressChan <- &Status{
+			Current: t.current,
+			Total:   t.total,
+		}
 	}
+
 	return n, err
 }
 
-// Copy tracks progress of copied data from src to dst.
+// Copy tracks progress of copied data from src to dst, progress events are
+// sent to the return status channel, once completed the IsFinished routine
+// will report true.
 func Copy(dst io.Writer, src io.Reader, n int64) (chan *Status, chan error) {
-	t := newTransmitter(dst, src)
-	t.total = n
+	t := newTransmitter(src, n)
 
-	go func(t *transmitter) {
+	go func() {
+		defer t.Close()
+
 		_, err := io.Copy(dst, t)
 		if err != nil {
 			t.errorChan <- err
+			return
 		}
-	}(t)
+
+		t.progressChan <- &Status{
+			Current:  t.total,
+			Total:    t.total,
+			finished: true,
+		}
+	}()
 
 	return t.progressChan, t.errorChan
 }

--- a/progress_test.go
+++ b/progress_test.go
@@ -24,13 +24,16 @@ func TestCopyFileSuccess(t *testing.T) {
 	var buf bytes.Buffer
 	progChan, errChan := Copy(&buf, file, stat.Size())
 
-	isCopied := false
-	for !isCopied {
+	for {
 		select {
 		case status := <-progChan:
 			if status.IsFinished() {
-				isCopied = true
-				break
+				// Actual testing occurs here.
+				if int64(buf.Len()) != stat.Size() {
+					t.Error("Copied length does not match file length")
+				}
+
+				return
 			}
 		case err := <-errChan:
 			t.Error(err)
@@ -48,13 +51,16 @@ func TestCopyGetRequestSuccess(t *testing.T) {
 	var buf bytes.Buffer
 	progChan, errChan := Copy(&buf, res.Body, res.ContentLength)
 
-	isCopied := false
-	for !isCopied {
+	for {
 		select {
 		case status := <-progChan:
 			if status.IsFinished() {
-				isCopied = true
-				break
+				// Actual testing occurs here.
+				if int64(buf.Len()) != res.ContentLength {
+					t.Error("Copied length does not match file length")
+				}
+
+				return
 			}
 		case err := <-errChan:
 			t.Error(err)

--- a/status.go
+++ b/status.go
@@ -2,12 +2,12 @@
 
 package progress
 
-// Status represents the download/upload progress.
-// It is comprised of the current progress (bytes)
-// and the total size (bytes)
+// Status represents the copy progress. It contains the current progress
+// and total size in bytes.
 type Status struct {
-	Current int64
-	Total   int64
+	Current  int64
+	Total    int64
+	finished bool
 }
 
 // Completion returns the current completion in the range [0, 1].
@@ -15,8 +15,8 @@ func (s *Status) Completion() float64 {
 	return float64(s.Current) / float64(s.Total)
 }
 
-// IsFinished returns a boolean indicating whether the
-// requests status is complete.
+// IsFinished returns a boolean indicating whether the copy
+// has completed.
 func (s *Status) IsFinished() bool {
-	return s.Current == s.Total
+	return s.finished
 }


### PR DESCRIPTION
Sup @sjkaliski, 

Please review the following commits I made in branch 'fix-race-cond'.

4de89b55b56dc2e019446e1126b3b7dc4747d753 (2015-04-15 09:47:48 -0400)
Fix race condition for Copy.
Since the IsFinished was be calculated by the progress and not by the
actual copy routine if the completion was 1 then it just stopped and
cleaned up(closing files, sockets, etc.) so the next Read call would
fail and cause a race condition. Instead we just have a static var to
say when it's actually completed and that's set after io.Copy returns.

R=@sjkaliski
